### PR TITLE
38 add zod validation for all inputs to match the backend

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 import { HealthRecordType } from "@/types/healthRecordTypes";
 
-const API_URL = "http://localhost:5000/health-records";
+const API_URL = "http://localhost:5555/health-records";
 
 export const getHealthRecord = async (id: number) => {
   try {

--- a/app/edit/EditConsultations.tsx
+++ b/app/edit/EditConsultations.tsx
@@ -118,7 +118,7 @@ const EditConsultations = () => {
             setLocalValue(
               addItem(localValue, {
                 consultant: "",
-                date: new Date().toISOString().split("T")[0],
+                date: new Date(),
                 diagnosis: "",
                 followUpActions: [],
               })

--- a/app/edit/EditConsultations.tsx
+++ b/app/edit/EditConsultations.tsx
@@ -19,6 +19,7 @@ import {
 import { SCREEN_LABELS } from "@/utils/constants";
 import { validators } from "@/utils/validators";
 
+
 const EditConsultations = () => {
   const { localValue, setLocalValue, handleSave, loading } = useEditForm(
     "medicalConsultations",
@@ -30,8 +31,8 @@ const EditConsultations = () => {
     setShowActionsMap((prev) => ({ ...prev, [index]: !prev[index] }));
   };
 
-  const handleDateChange = (index: number, dateString: string) =>
-    setLocalValue(updateItemProperty(localValue, index, "date", dateString));
+  const handleDateChange = (index: number, date: Date) =>
+    setLocalValue(updateItemProperty(localValue, index, "date", new Date(date)));
 
   const getConsultationDate = (consultation: MedicalConsultation) =>
     consultation.date ? new Date(consultation.date) : new Date();

--- a/app/edit/EditSymptoms.tsx
+++ b/app/edit/EditSymptoms.tsx
@@ -49,7 +49,7 @@ const EditSymptoms = () => {
         <TouchableOpacity
           style={commonStyles.btn}
           onPress={() =>
-            setLocalValue(addItem(localValue, { name: "", startDate: new Date().toISOString().split("T")[0] }))
+            setLocalValue(addItem(localValue, { name: "", startDate: new Date() }))
           }
         >
           <Text>Add Symptom</Text>

--- a/app/edit/EditSymptoms.tsx
+++ b/app/edit/EditSymptoms.tsx
@@ -14,8 +14,8 @@ import { validators } from "@/utils/validators";
 const EditSymptoms = () => {
   const { localValue, setLocalValue, handleSave, loading } = useEditForm("symptoms", validators.symptoms);
 
-  const handleDateChange = (index: number, dateString: string) => {
-    setLocalValue(updateItemProperty(localValue, index, "startDate", dateString));
+  const handleDateChange = (index: number, date: Date) => {
+    setLocalValue(updateItemProperty(localValue, index, "startDate", date));
   };
 
   const getSymptomDate = (symptom: Symptom) => (symptom.startDate ? new Date(symptom.startDate) : new Date());
@@ -49,7 +49,7 @@ const EditSymptoms = () => {
         <TouchableOpacity
           style={commonStyles.btn}
           onPress={() =>
-            setLocalValue(addItem(localValue, { name: "", startDate: new Date().toISOString().split("T")[0] }))
+            setLocalValue(addItem(localValue, { name: "", startDate: new Date() }))
           }
         >
           <Text>Add Symptom</Text>

--- a/app/edit/EditSymptoms.tsx
+++ b/app/edit/EditSymptoms.tsx
@@ -49,7 +49,7 @@ const EditSymptoms = () => {
         <TouchableOpacity
           style={commonStyles.btn}
           onPress={() =>
-            setLocalValue(addItem(localValue, { name: "", startDate: new Date() }))
+            setLocalValue(addItem(localValue, { name: "", startDate: new Date().toISOString().split("T")[0] }))
           }
         >
           <Text>Add Symptom</Text>

--- a/hooks/useDatePicker.ts
+++ b/hooks/useDatePicker.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { CalendarDate } from "react-native-paper-dates/lib/typescript/Date/Calendar";
 
 type UseDatePickerProps<T> = {
-  onDateChange: (index: number, date: string) => void;
+  onDateChange: (index: number, date: Date) => void;
   getItemDate: (item: T) => Date;
 };
 
@@ -19,7 +19,7 @@ export function useDatePicker<T>({ onDateChange, getItemDate }: UseDatePickerPro
 
   const handleConfirmDate = (date: CalendarDate) => {
     if (selectedItemIndex !== null && date) {
-      onDateChange(selectedItemIndex, date.toISOString().split("T")[0]);
+      onDateChange(selectedItemIndex, date);
     }
     closeDatePicker();
   };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",
-    "start:mock": "json-server --watch db.json --port 5000",
+    "start:mock": "json-server --watch db.json --port 5555",
     "reset-project": "node ./scripts/reset-project.js",
     "android": "expo start --android",
     "ios": "expo start --ios",

--- a/types/healthRecordTypes.ts
+++ b/types/healthRecordTypes.ts
@@ -145,6 +145,8 @@ export const Z_HealthRecord = z.object({
 // }
 
 export const Z_SymptomsArray = z.array(Z_Symptom);
+export const Z_MedicalConsultationArray = z.array(Z_MedicalConsultation);
+
 
 export type Stage = z.infer<typeof Z_Stage>;
 export type Severity = z.infer<typeof Z_Severity>;

--- a/types/healthRecordTypes.ts
+++ b/types/healthRecordTypes.ts
@@ -5,14 +5,15 @@ import {
   MAX_CHAR_LONG,
   minValidationMessage,
   maxValidationMessage,
-  STATUS_TYPES,
-  IMPROVEMENT_STATUS,
-  SEVERITY_TYPES
 } from "@/utils/constants";
 
-export type Stage = "open" | "closed" | "in-progress";
-export type Severity = "mild" | "moderate" | "severe" | "variable";
-export type Progression = "improving" | "stable" | "worsening" | "variable";
+export const Z_Stage = z.enum(["open", "closed", "in-progress"]);
+export const Z_Severity = z.enum(["mild", "moderate", "severe", "variable"]);
+export const Z_Progression = z.enum(["improving", "stable", "worsening", "variable"]);
+
+// export type Stage = "open" | "closed" | "in-progress";
+// export type Severity = "mild" | "moderate" | "severe" | "variable";
+// export type Progression = "improving" | "stable" | "worsening" | "variable";
 
 export type StatusOptionsType = {
   stage: { label: string; value: Stage }[];
@@ -20,7 +21,7 @@ export type StatusOptionsType = {
   progression: { label: string; value: Progression }[];
 };
 
-const Z_Symptoms = z.object({
+export const Z_Symptom = z.object({
   name: z
     .string()
     .trim()
@@ -31,67 +32,96 @@ const Z_Symptoms = z.object({
   // startDate: z.date().max(new Date(), "Start date cannot be in the future").optional(),
 });
 
-export type Symptom = z.infer<typeof Z_Symptoms>;
-
 // export interface Symptom {
 //   name: string;
 //   startDate: string;
 // }
 
-// const Z_MedicalConsultation = z.object({
-//   consultant: z
-//     .string()
-//     .trim()
-//     .min(2, minValidationMessage("Consultant", 2))
-//     .max(MAX_CHAR_SHORT, maxValidationMessage("Consultant", MAX_CHAR_SHORT)),
-//   date: z.date().max(new Date(), "Consultation date cannot be in the future"),
-//   diagnosis: z
-//     .string()
-//     .trim()
-//     .min(1, "Diagnosis is required")
-//     .max(MAX_CHAR_LONG, maxValidationMessage("Diagnosis", MAX_CHAR_LONG)),
-//   followUpActions: z
-//     .array(
-//       z
-//         .string()
-//         .trim()
-//         .min(2, minValidationMessage("Follow-up actions", 2))
-//         .max(MAX_CHAR_LONG, maxValidationMessage("Follow-up actions", MAX_CHAR_LONG))
-//     )
-//     .optional()
-//     .default([]),
-// });
+export const Z_MedicalConsultation = z.object({
+  consultant: z
+    .string()
+    .trim()
+    .min(2, minValidationMessage("Consultant", 2))
+    .max(MAX_CHAR_SHORT, maxValidationMessage("Consultant", MAX_CHAR_SHORT)),
+  date: z.date().max(new Date(), "Consultation date cannot be in the future"),
+  diagnosis: z
+    .string()
+    .trim()
+    .min(1, "Diagnosis is required")
+    .max(MAX_CHAR_LONG, maxValidationMessage("Diagnosis", MAX_CHAR_LONG)),
+  followUpActions: z
+    .array(
+      z
+        .string()
+        .trim()
+        .min(2, minValidationMessage("Follow-up actions", 2))
+        .max(MAX_CHAR_LONG, maxValidationMessage("Follow-up actions", MAX_CHAR_LONG))
+    )
+    .optional()
+    .default([]),
+});
 
-// export type MedicalConsultation = z.infer<typeof Z_MedicalConsultation>;
+// export interface MedicalConsultation {
+//   consultant: string;
+//   date: string;
+//   diagnosis: string;
+//   followUpActions?: string[];
+// }
 
-export interface MedicalConsultation {
-  consultant: string;
-  date: string;
-  diagnosis: string;
-  followUpActions?: string[];
-}
+export const Z_HealthRecordUpdate = z.object({
+  description: z.string().optional(),
+  symptoms: z.array(Z_Symptom).optional(),
+  status: z.object({
+    stage: Z_Stage.optional(),
+    severity: Z_Severity.optional(),
+    progression: Z_Progression.optional(),
+  }).optional(),
+  treatmentsTried: z.array(z.string()).optional(),
+  medicalConsultations: z.array(Z_MedicalConsultation).optional(),
+});
 
-export interface HealthRecordUpdateType {
-  description?: string;
-  symptoms?: Symptom[];
-  status?: {
-    stage?: Stage;
-    severity?: Severity;
-    progression?: Progression;
-  };
-  treatmentsTried?: string[];
-  medicalConsultations?: MedicalConsultation[];
-}
+// export interface HealthRecordUpdateType {
+//   description?: string;
+//   symptoms?: Symptom[];
+//   status?: {
+//     stage?: Stage;
+//     severity?: Severity;
+//     progression?: Progression;
+//   };
+//   treatmentsTried?: string[];
+//   medicalConsultations?: MedicalConsultation[];
+// }
 
-export interface HealthRecordType {
-  description: string;
-  symptoms: Symptom[];
-  status: {
-    stage: Stage;
-    severity: Severity;
-    progression: Progression;
-  };
-  treatmentsTried?: string[];
-  medicalConsultations?: MedicalConsultation[];
-  updates?: HealthRecordUpdateType[];
-}
+export const Z_HealthRecord = z.object({
+  description: z.string(),
+  symptoms: z.array(Z_Symptom),
+  status: z.object({
+    stage: Z_Stage,
+    severity: Z_Severity,
+    progression: Z_Progression,
+  }),
+  treatmentsTried: z.array(z.string()).optional(),
+  medicalConsultations: z.array(Z_MedicalConsultation).optional(),
+  updates: z.array(Z_HealthRecordUpdate).optional(),
+});
+
+// export interface HealthRecordType {
+//   description: string;
+//   symptoms: Symptom[];
+//   status: {
+//     stage: Stage;
+//     severity: Severity;
+//     progression: Progression;
+//   };
+//   treatmentsTried?: string[];
+//   medicalConsultations?: MedicalConsultation[];
+//   updates?: HealthRecordUpdateType[];
+// }
+
+export type Stage = z.infer<typeof Z_Stage>;
+export type Severity = z.infer<typeof Z_Severity>;
+export type Progression = z.infer<typeof Z_Progression>;
+export type Symptom = z.infer<typeof Z_Symptom>;
+export type MedicalConsultation = z.infer<typeof Z_MedicalConsultation>;
+export type HealthRecordUpdateType = z.infer<typeof Z_HealthRecordUpdate>;
+export type HealthRecordType = z.infer<typeof Z_HealthRecord>;

--- a/types/healthRecordTypes.ts
+++ b/types/healthRecordTypes.ts
@@ -21,6 +21,14 @@ export type StatusOptionsType = {
   progression: { label: string; value: Progression }[];
 };
 
+export const Z_Description = z.object({
+  description: z
+    .string()
+    .min(10, "Longer description is required")
+    .max(MAX_CHAR_MEDIUM, "Maximum length for description reached"),
+});
+
+
 export const Z_Symptom = z.object({
   name: z
     .string()
@@ -118,9 +126,12 @@ export const Z_HealthRecord = z.object({
 //   updates?: HealthRecordUpdateType[];
 // }
 
+export const Z_SymptomsArray = z.array(Z_Symptom);
+
 export type Stage = z.infer<typeof Z_Stage>;
 export type Severity = z.infer<typeof Z_Severity>;
 export type Progression = z.infer<typeof Z_Progression>;
+export type Description = z.infer<typeof Z_Description>;
 export type Symptom = z.infer<typeof Z_Symptom>;
 export type MedicalConsultation = z.infer<typeof Z_MedicalConsultation>;
 export type HealthRecordUpdateType = z.infer<typeof Z_HealthRecordUpdate>;

--- a/types/healthRecordTypes.ts
+++ b/types/healthRecordTypes.ts
@@ -1,3 +1,15 @@
+import { z } from "zod";
+import {
+  MAX_CHAR_SHORT,
+  MAX_CHAR_MEDIUM,
+  MAX_CHAR_LONG,
+  minValidationMessage,
+  maxValidationMessage,
+  STATUS_TYPES,
+  IMPROVEMENT_STATUS,
+  SEVERITY_TYPES
+} from "@/utils/constants";
+
 export type Stage = "open" | "closed" | "in-progress";
 export type Severity = "mild" | "moderate" | "severe" | "variable";
 export type Progression = "improving" | "stable" | "worsening" | "variable";
@@ -8,10 +20,23 @@ export type StatusOptionsType = {
   progression: { label: string; value: Progression }[];
 };
 
-export interface Symptom {
-  name: string;
-  startDate: string;
-}
+const Z_Symptoms = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Symptom name is required")
+    .max(MAX_CHAR_MEDIUM, maxValidationMessage("Symptom", MAX_CHAR_MEDIUM)),
+  startDate: z.date().optional(),
+  // TODO: This is causing some strange behaviour, will address it in the future
+  // startDate: z.date().max(new Date(), "Start date cannot be in the future").optional(),
+});
+
+export type Symptom = z.infer<typeof Z_Symptoms>;
+
+// export interface Symptom {
+//   name: string;
+//   startDate: string;
+// }
 
 export interface MedicalConsultation {
   consultant: string;

--- a/types/healthRecordTypes.ts
+++ b/types/healthRecordTypes.ts
@@ -26,7 +26,7 @@ const Z_Symptoms = z.object({
     .trim()
     .min(1, "Symptom name is required")
     .max(MAX_CHAR_MEDIUM, maxValidationMessage("Symptom", MAX_CHAR_MEDIUM)),
-  startDate: z.date().optional(),
+  startDate: z.string().optional(),
   // TODO: This is causing some strange behaviour, will address it in the future
   // startDate: z.date().max(new Date(), "Start date cannot be in the future").optional(),
 });

--- a/types/healthRecordTypes.ts
+++ b/types/healthRecordTypes.ts
@@ -26,7 +26,7 @@ const Z_Symptoms = z.object({
     .trim()
     .min(1, "Symptom name is required")
     .max(MAX_CHAR_MEDIUM, maxValidationMessage("Symptom", MAX_CHAR_MEDIUM)),
-  startDate: z.string().optional(),
+  startDate: z.date().optional(),
   // TODO: This is causing some strange behaviour, will address it in the future
   // startDate: z.date().max(new Date(), "Start date cannot be in the future").optional(),
 });
@@ -37,6 +37,32 @@ export type Symptom = z.infer<typeof Z_Symptoms>;
 //   name: string;
 //   startDate: string;
 // }
+
+// const Z_MedicalConsultation = z.object({
+//   consultant: z
+//     .string()
+//     .trim()
+//     .min(2, minValidationMessage("Consultant", 2))
+//     .max(MAX_CHAR_SHORT, maxValidationMessage("Consultant", MAX_CHAR_SHORT)),
+//   date: z.date().max(new Date(), "Consultation date cannot be in the future"),
+//   diagnosis: z
+//     .string()
+//     .trim()
+//     .min(1, "Diagnosis is required")
+//     .max(MAX_CHAR_LONG, maxValidationMessage("Diagnosis", MAX_CHAR_LONG)),
+//   followUpActions: z
+//     .array(
+//       z
+//         .string()
+//         .trim()
+//         .min(2, minValidationMessage("Follow-up actions", 2))
+//         .max(MAX_CHAR_LONG, maxValidationMessage("Follow-up actions", MAX_CHAR_LONG))
+//     )
+//     .optional()
+//     .default([]),
+// });
+
+// export type MedicalConsultation = z.infer<typeof Z_MedicalConsultation>;
 
 export interface MedicalConsultation {
   consultant: string;

--- a/types/healthRecordTypes.ts
+++ b/types/healthRecordTypes.ts
@@ -11,15 +11,33 @@ export const Z_Stage = z.enum(["open", "closed", "in-progress"]);
 export const Z_Severity = z.enum(["mild", "moderate", "severe", "variable"]);
 export const Z_Progression = z.enum(["improving", "stable", "worsening", "variable"]);
 
+const Z_LabeledEnumOption = <T extends z.ZodTypeAny>(enumSchema: T) =>
+  z.object({
+    label: z.string(),
+    value: enumSchema,
+  });
+
+  export const Z_StatusOptions = z.object({
+    stage: z.array(Z_LabeledEnumOption(Z_Stage)),
+    severity: z.array(Z_LabeledEnumOption(Z_Severity)),
+    progression: z.array(Z_LabeledEnumOption(Z_Progression)),
+  });
+
+  export const Z_Status = z.object({
+    stage: Z_Stage,
+    severity: Z_Severity,
+    progression: Z_Progression,
+  });
+
 // export type Stage = "open" | "closed" | "in-progress";
 // export type Severity = "mild" | "moderate" | "severe" | "variable";
 // export type Progression = "improving" | "stable" | "worsening" | "variable";
 
-export type StatusOptionsType = {
-  stage: { label: string; value: Stage }[];
-  severity: { label: string; value: Severity }[];
-  progression: { label: string; value: Progression }[];
-};
+// export type StatusOptionsType = {
+//   stage: { label: string; value: Stage }[];
+//   severity: { label: string; value: Severity }[];
+//   progression: { label: string; value: Progression }[];
+// };
 
 export const Z_Description = z.object({
   description: z
@@ -131,6 +149,8 @@ export const Z_SymptomsArray = z.array(Z_Symptom);
 export type Stage = z.infer<typeof Z_Stage>;
 export type Severity = z.infer<typeof Z_Severity>;
 export type Progression = z.infer<typeof Z_Progression>;
+export type StatusOptionsType = z.infer<typeof Z_StatusOptions>;
+export type Status = z.infer<typeof Z_Status>;
 export type Description = z.infer<typeof Z_Description>;
 export type Symptom = z.infer<typeof Z_Symptom>;
 export type MedicalConsultation = z.infer<typeof Z_MedicalConsultation>;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -64,3 +64,7 @@ export function maxValidationMessage(item: string, max: number) {
 export function minValidationMessage(item: string, min: number) {
   return `${item} should be more than ${min} characters`;
 }
+
+export const STATUS_TYPES = ["open", "closed", "in-progress"] as const;
+export const IMPROVEMENT_STATUS = ["improving", "stable", "worsening", "variable"] as const;
+export const SEVERITY_TYPES = ["mild", "moderate", "severe", "variable"] as const;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -64,7 +64,3 @@ export function maxValidationMessage(item: string, max: number) {
 export function minValidationMessage(item: string, min: number) {
   return `${item} should be more than ${min} characters`;
 }
-
-export const STATUS_TYPES = ["open", "closed", "in-progress"] as const;
-export const IMPROVEMENT_STATUS = ["improving", "stable", "worsening", "variable"] as const;
-export const SEVERITY_TYPES = ["mild", "moderate", "severe", "variable"] as const;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -51,3 +51,16 @@ export const statusConfigs = [
   { field: "severity", title: "Severity", zIndex: 2000, zIndexInverse: 2000 },
   { field: "progression", title: "Progression", zIndex: 1000, zIndexInverse: 3000 },
 ] as const;
+
+
+export const MAX_CHAR_SHORT = 100;
+export const MAX_CHAR_MEDIUM = 1000;
+export const MAX_CHAR_LONG = 10_000;
+
+export function maxValidationMessage(item: string, max: number) {
+  return `${item} must be less than ${max} characters`;
+}
+
+export function minValidationMessage(item: string, min: number) {
+  return `${item} should be more than ${min} characters`;
+}

--- a/utils/dateFormatter.ts
+++ b/utils/dateFormatter.ts
@@ -1,0 +1,8 @@
+export const formatDateStrict = (date: Date): string => {
+  return date.toISOString().split("T")[0];
+};
+
+export const formatDateToYMD = (date?: Date | null) => {
+  if (!date) return "";
+  return date.toISOString().split("T")[0];
+};

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,4 +1,4 @@
-import { MedicalConsultation, Progression, Severity, Stage, Description, Symptom, Z_SymptomsArray, Z_Status } from "@/types/healthRecordTypes";
+import { MedicalConsultation, Progression, Severity, Stage, Description, Symptom, Z_Status, Z_SymptomsArray, Z_MedicalConsultationArray } from "@/types/healthRecordTypes";
 
 export const validators = {
   description: (description: Description) => ({
@@ -38,16 +38,19 @@ export const validators = {
     };
   },
 
-  medicalConsultations: (medicalConsultations: MedicalConsultation[]) => ({
-    valid:
-      medicalConsultations &&
-      medicalConsultations.every(
-        (consultation) =>
-          consultation.consultant.trim().length > 0 &&
-          consultation.date &&
-          consultation.diagnosis.trim().length > 0 &&
-          consultation.followUpActions?.every((action) => action.trim().length > 0)
-      ),
-    message: "All fields are required!",
-  }),
+  medicalConsultations: (consultations: MedicalConsultation[]) => {
+    const normalized = consultations.map((c) => ({
+      ...c,
+      date: typeof c.date === "string" ? new Date(c.date) : c.date,
+    }));
+
+    const result = Z_MedicalConsultationArray.safeParse(normalized);
+
+    return {
+      valid: result.success,
+      message: result.success
+        ? ""
+        : result.error.errors.map((e) => e.message).join(", "),
+    };
+  },
 };

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,15 +1,27 @@
-import { MedicalConsultation, Progression, Severity, Stage, Symptom } from "@/types/healthRecordTypes";
+import { MedicalConsultation, Progression, Severity, Stage, Description, Symptom, Z_SymptomsArray } from "@/types/healthRecordTypes";
 
 export const validators = {
-  description: (value: string) => ({
-    valid: value.trim().length >= 10,
+  description: (description: Description) => ({
+    valid: description.description,
     message: "Description must be at least 10 characters long!",
   }),
 
-  symptoms: (symptoms: Symptom[]) => ({
-    valid: symptoms.every((symptom) => symptom.startDate && symptom.name.trim().length > 0),
-    message: "All fields are required!",
-  }),
+  symptoms: (symptoms: Symptom[]) => {
+    const normalized = symptoms.map((s) => ({
+      ...s,
+      startDate:
+        typeof s.startDate === "string" ? new Date(s.startDate) : s.startDate,
+    }));
+
+    const result = Z_SymptomsArray.safeParse(normalized);
+
+    return {
+      valid: result.success,
+      message: result.success
+        ? ""
+        : result.error.errors.map((e) => e.message).join(", "),
+    };
+  },
 
   treatmentsTried: (treatments: string[]) => ({
     valid: treatments && treatments.every((treatment) => treatment.trim().length >= 3),

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,4 +1,4 @@
-import { MedicalConsultation, Progression, Severity, Stage, Description, Symptom, Z_SymptomsArray } from "@/types/healthRecordTypes";
+import { MedicalConsultation, Progression, Severity, Stage, Description, Symptom, Z_SymptomsArray, Z_Status } from "@/types/healthRecordTypes";
 
 export const validators = {
   description: (description: Description) => ({
@@ -12,7 +12,6 @@ export const validators = {
       startDate:
         typeof s.startDate === "string" ? new Date(s.startDate) : s.startDate,
     }));
-
     const result = Z_SymptomsArray.safeParse(normalized);
 
     return {
@@ -28,16 +27,16 @@ export const validators = {
     message: "Each treatment must be at least 3 characters long!",
   }),
 
-  status: (status: { stage: Stage; severity: Severity; progression: Progression }) => ({
-    valid:
-      status.stage &&
-      status.severity &&
-      status.progression &&
-      ["open", "closed", "in-progress"].includes(status.stage) &&
-      ["mild", "moderate", "severe", "variable"].includes(status.severity) &&
-      ["improving", "stable", "worsening", "variable"].includes(status.progression),
-    message: "Invalid status value(s)!",
-  }),
+  status: (status: { stage: Stage; severity: Severity; progression: Progression }) => {
+    const result = Z_Status.safeParse(status);
+
+    return {
+      valid: result.success,
+      message: result.success
+        ? ""
+        : result.error.errors.map((e) => e.message).join(", "),
+    };
+  },
 
   medicalConsultations: (medicalConsultations: MedicalConsultation[]) => ({
     valid:


### PR DESCRIPTION
Implementing Zod validation & replacing current validation system.

For the most part I copied the structure for the types from the Zod schemas declared in the backend as suggested, apart from HealthRecord where the structure of status has been updated. *This will need to be addressed in the backend.*

I replaced the old interfaces in the types file with the Zod schemas ( I will remove the commented out code when the PR is given the green-light, it's there as a reference to what has been replaced. )

There has been some small changes made throughout the codebase to account for the several schemas that have changed date strings to date objects.

This date string to date object change has also affected the display of dates in the UI which must be addressed as it is no longer in a tidy format. *I began writing a helper function in the utils folder to help with the formatting*

After Zod Schemas were added, they were implemented in the validators file to allow type checking during runtime.

Some additional constants taken from the backend have been saved in the constants file.


