### PR TITLE
60 configure typescript for pre commit type checking

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+npx lint-staged && npm run tsc

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint:es
+npx lint-staged

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "eslint.validate": ["typescript", "typescriptreact"],
+  "eslint.validate": ["typescript", "typescriptreact", "javascript"],
   "typescript.updateImportsOnFileMove.enabled": "always",
   "javascript.updateImportsOnFileMove.enabled": "always",
   "editor.tabSize": 2,

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
       "prettier --write"
     ],
     "*.{ts,tsx,js}": [
-      "eslint --fix"
+      "eslint"
     ]
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:es": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
+    "tsc": "tsc",
     "prepare": "husky && husky install"
   },
   "jest": {
@@ -85,6 +86,9 @@
     ],
     "*.{ts,tsx,js}": [
       "eslint"
+    ],
+    "*.{ts,tsx}": [
+      "npm run tsc"
     ]
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -86,9 +86,6 @@
     ],
     "*.{ts,tsx,js}": [
       "eslint"
-    ],
-    "*.{ts,tsx}": [
-      "npm run tsc"
     ]
   },
   "private": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,16 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "jsx": "react-native",
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    ".expo/types/**/*.ts",
-    "expo-env.d.ts"
-  ]
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"],
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
 }


### PR DESCRIPTION
- Refined ```tsconfig.json``` to align to mobile version with Expo requirements
- Added type-checking related scripts to package.json
- Updated the pre-commit hook to run lint-staged, ensuring only staged files are formatted and linted during commits
- Introduced a dedicated type-checking step in pre-commit hook that runs across the entire codebase, rather than including in into ```file-staged```
> This was necessary because ```tsc``` cannot be combined with individual files passed by lint-staged, since type checking requires global context (needs to be run globally) -- staged files may depend on types, interfaces, or modules defined in other parts of the codebase.